### PR TITLE
Allow Closing to detect dependent resources passed as kwargs too #636

### DIFF
--- a/src/dependency_injector/wiring.py
+++ b/src/dependency_injector/wiring.py
@@ -598,7 +598,7 @@ def _locate_dependent_closing_args(provider: providers.Provider) -> Dict[str, pr
         return {}
 
     closing_deps = {}
-    for arg in provider.args:
+    for arg in [*provider.args, *provider.kwargs.values()]:
         if not isinstance(arg, providers.Provider) or not hasattr(arg, "args"):
             continue
 

--- a/src/dependency_injector/wiring.py
+++ b/src/dependency_injector/wiring.py
@@ -605,7 +605,7 @@ def _locate_dependent_closing_args(provider: providers.Provider) -> Dict[str, pr
         if not arg.args and isinstance(arg, providers.Resource):
             return {str(id(arg)): arg}
         else:
-            closing_deps += _locate_dependent_closing_args(arg)
+            closing_deps |= _locate_dependent_closing_args(arg)
     return closing_deps
 
 

--- a/tests/unit/samples/wiringstringids/resourceclosing.py
+++ b/tests/unit/samples/wiringstringids/resourceclosing.py
@@ -36,6 +36,7 @@ class Container(containers.DeclarativeContainer):
 
     service = providers.Resource(init_service)
     factory_service = providers.Factory(FactoryService, service)
+    factory_service_kwargs = providers.Factory(FactoryService, service=service)
 
 
 @inject
@@ -45,4 +46,9 @@ def test_function(service: Service = Closing[Provide["service"]]):
 
 @inject
 def test_function_dependency(factory: FactoryService = Closing[Provide["factory_service"]]):
+    return factory
+
+
+@inject
+def test_function_dependency_kwargs(factory: FactoryService = Closing[Provide["factory_service_kwargs"]]):
     return factory

--- a/tests/unit/wiring/string_ids/test_main_py36.py
+++ b/tests/unit/wiring/string_ids/test_main_py36.py
@@ -303,7 +303,20 @@ def test_closing_dependency_resource():
     assert result_2.service.init_counter == 2
     assert result_2.service.shutdown_counter == 2
 
-    assert result_1 is not result_2
+
+@mark.usefixtures("resourceclosing_container")
+def test_closing_dependency_resource_kwargs():
+    resourceclosing.Service.reset_counter()
+
+    result_1 = resourceclosing.test_function_dependency_kwargs()
+    assert isinstance(result_1, resourceclosing.FactoryService)
+    assert result_1.service.init_counter == 1
+    assert result_1.service.shutdown_counter == 1
+
+    result_2 = resourceclosing.test_function_dependency_kwargs()
+    assert isinstance(result_2, resourceclosing.FactoryService)
+    assert result_2.service.init_counter == 2
+    assert result_2.service.shutdown_counter == 2
 
 
 @mark.usefixtures("resourceclosing_container")


### PR DESCRIPTION
A small addiction to the work of @StummeJ about issue https://github.com/ets-labs/python-dependency-injector/issues/633 which allows to benefit of his improvement even for dependencies passed as kwargs (such as my case)

UPDATE: integrated with @jazzthief PR ets-labs/python-dependency-injector#711